### PR TITLE
Improve issue template with clearer guidance on issue types and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,43 +4,37 @@ about: Create a report to help us improve and fix any bugs in our coding
 title: Bug Report
 labels: bug
 assignees: Altify-Development
-
 ---
 
-**Describe the bug**
-![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+R)![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+E)![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+Q)![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+U)![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+I)![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+R)![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+E)![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+D)
-
+## Describe the bug
 A clear and concise description of what the bug is.
 
-**To Reproduce**
-![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+R)![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+E)![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+Q)![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+U)![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+I)![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+R)![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+E)![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+D)
-
+## To Reproduce
 Steps to reproduce the behavior:
-![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+R)![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+E)![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+Q)![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+U)![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+I)![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+R)![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+E)![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+D)
-
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+## Expected behavior
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
+## Screenshots
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
-![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+R)![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+E)![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+Q)![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+U)![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+I)![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+R)![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+E)![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+D)
+## System Information
+Please provide the following system information:
+- **OS**: [e.g., Windows 10, macOS Big Sur, Ubuntu 20.04]
+- **Browser**: [e.g., Chrome, Firefox, Safari]
+- **Browser Version**: [e.g., 95.0]
+- **Node.js Version** (if applicable): [e.g., 16.13.0]
+- **Package Version**: [e.g., 1.0.0]
 
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+## Logs & Error Messages
+Please provide any relevant error messages or logs:
+```
+Paste error output or logs here
+```
 
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
-
-**Additional context**
+## Additional context
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/issue-template.md
+++ b/.github/ISSUE_TEMPLATE/issue-template.md
@@ -7,8 +7,11 @@ assignees: Altify-Development
 
 ---
 
-Issue tracker is **ONLY** used for reporting bugs. New features should be discussed on our slack channel. Please use [stackoverflow](https://stackoverflow.com) for supporting issues.
+**Issue tracker is ONLY used for reporting bugs.**
 
+For general troubleshooting and usage questions, please use [Stack Overflow](https://stackoverflow.com/). The issue tracker is exclusively for bug reports.
+
+If you're reporting a bug that's related to a feature request, please report the bug here and discuss the feature request separately on our Slack channel.
 <!--- Provide a general summary of the issue in the Title above -->
 
 ## Expected Behavior


### PR DESCRIPTION
## Summary
This PR addresses issue #130 by improving the issue template to provide clearer guidance on issue categorization and handling mixed bug/feature requests.

## Changes Made
- Clarified the phrase "supporting issues" to explicitly state "general troubleshooting and usage questions"
- Added explicit guidance to use Stack Overflow for general questions
- Added clear instructions for handling issues that are a mix of bug reports and feature requests
- Reorganized the intro text for better clarity and understanding

## Related Issue
Fixes #130

## Testing
The updated template now provides clearer guidance for issue reporters to understand:
1. That the issue tracker is ONLY for bug reports
2. Where to go for general usage questions (Stack Overflow)
3. How to handle mixed bug/feature requests